### PR TITLE
频率扩展到硬件灵敏度极限

### DIFF
--- a/frequencies.c
+++ b/frequencies.c
@@ -24,7 +24,7 @@
 #define BX4819_band2_upper 130000000
 
 const freq_band_table_t BX4819_band1 = {BX4819_band1_lower,  63000000};
-const freq_band_table_t BX4819_band2 = {84000000, BX4819_band2_upper};
+const freq_band_table_t BX4819_band2 = {76000000, BX4819_band2_upper};
 
 const freq_band_table_t frequencyBandTable[] =
         {


### PR DESCRIPTION
![QQ截图20240115002927](https://github.com/losehu/uv-k5-firmware-chinese/assets/135425477/c3d04017-ed6d-4182-974b-3e1ce163e921)

OneOfEleven 使用了规格书定义的频率范围，但实际可以到 760MHz+